### PR TITLE
Don't try to open GITHUB_OUTPUT as a binary file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
         def set_output(k, v):
           s = f"{k}={v}"
           print("Set output:", s)
-          with open(os.environ["GITHUB_OUTPUT"], "ab") as f:
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(s)
 
         def extract_tag(_pr_body, _tag_regex):


### PR DESCRIPTION
Sorry, this was my bad!

When trying to open it as a binary file the action will fail with this error:

```
TypeError: a bytes-like object is required, not 'str'
```

<img width="1149" height="587" alt="CleanShot 2025-09-05 at 11 30 40" src="https://github.com/user-attachments/assets/da3fc0cd-ed2f-48a4-82f5-538db2329a7a" />
